### PR TITLE
make default locale redirect #229

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -144,3 +144,10 @@ pages_support:
     methods:    GET
     requirements:
       _locale:  en|es|fr
+
+home_fallback:
+    path: /
+    controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController::urlRedirectAction
+    defaults:
+        path: /en
+        permanent: true


### PR DESCRIPTION
let application route to the default locale instead of give 404 error on the main page (or delegate this feature to nginx)

Do not forget to remove redirect construction from nginx/docker config